### PR TITLE
[improve][deploy] changed the default GC options to ZGC from G1GC

### DIFF
--- a/bin/function-localrunner
+++ b/bin/function-localrunner
@@ -37,7 +37,7 @@ fi
 PULSAR_MEM=${PULSAR_MEM:-"-Xmx128m -XX:MaxDirectMemorySize=128m"}
 
 # Garbage collection options
-PULSAR_GC=${PULSAR_GC:-"-XX:+UseG1GC -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+DoEscapeAnalysis -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC"}
+PULSAR_GC=${PULSAR_GC:-"-XX:+UseZGC -XX:+PerfDisableSharedMem -XX:+AlwaysPreTouch"}
 
 # Garbage collection log.
 IS_JAVA_8=`$JAVA -version 2>&1 |grep version|grep '"1\.8'`

--- a/conf/bkenv.sh
+++ b/conf/bkenv.sh
@@ -38,7 +38,7 @@ BOOKIE_CONF=${BOOKIE_CONF:-"$BK_HOME/conf/bookkeeper.conf"}
 BOOKIE_MEM=${BOOKIE_MEM:-${PULSAR_MEM:-"-Xms2g -Xmx2g -XX:MaxDirectMemorySize=2g"}}
 
 # Garbage collection options
-BOOKIE_GC=${BOOKIE_GC:-${PULSAR_GC:-"-XX:+UseG1GC -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC"}}
+BOOKIE_GC=${BOOKIE_GC:-${PULSAR_GC:-"-XX:+UseZGC -XX:+PerfDisableSharedMem -XX:+AlwaysPreTouch"}}
 
 if [ -z "$JAVA_HOME" ]
 then

--- a/conf/presto/jvm.config
+++ b/conf/presto/jvm.config
@@ -19,8 +19,7 @@
 
 -server
 -Xmx16G
--XX:+UseG1GC
--XX:G1HeapRegionSize=32M
+-XX:+UseZGC
 -XX:+UseGCOverheadLimit
 -XX:+ExplicitGCInvokesConcurrent
 -XX:+HeapDumpOnOutOfMemoryError

--- a/conf/pulsar_env.sh
+++ b/conf/pulsar_env.sh
@@ -45,7 +45,7 @@
 PULSAR_MEM=${PULSAR_MEM:-"-Xms2g -Xmx2g -XX:MaxDirectMemorySize=4g"}
 
 # Garbage collection options
-PULSAR_GC=${PULSAR_GC:-"-XX:+UseG1GC -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC"}
+PULSAR_GC=${PULSAR_GC:-"-XX:+UseZGC -XX:+PerfDisableSharedMem -XX:+AlwaysPreTouch"}
 
 # Garbage collection log.
 if [ -z "$JAVA_HOME" ]

--- a/deployment/terraform-ansible/templates/pulsar_env.sh
+++ b/deployment/terraform-ansible/templates/pulsar_env.sh
@@ -45,10 +45,10 @@
 PULSAR_MEM=" -Xms{{ max_heap_memory }} -Xmx{{ max_heap_memory }} -XX:MaxDirectMemorySize={{ max_direct_memory }}"
 
 # Garbage collection options
-PULSAR_GC=" -XX:+UseG1GC -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC"
+PULSAR_GC=" -XX:+UseZGC -XX:+PerfDisableSharedMem -XX:+AlwaysPreTouch"
 
 # Extra options to be passed to the jvm
-PULSAR_EXTRA_OPTS="${PULSAR_EXTRA_OPTS} ${PULSAR_MEM} ${PULSAR_GC} -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.maxCapacityPerThread=4096"
+PULSAR_EXTRA_OPTS="${PULSAR_EXTRA_OPTS} -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.maxCapacityPerThread=4096"
 
 # Add extra paths to the bookkeeper classpath
 # PULSAR_EXTRA_CLASSPATH=

--- a/pom.xml
+++ b/pom.xml
@@ -1420,7 +1420,7 @@ flexible messaging model and an intuitive client API.</description>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <argLine>${testJacocoAgentArgument} -XX:+ExitOnOutOfMemoryError -Xmx1G -XX:+UseG1GC
+          <argLine>${testJacocoAgentArgument} -XX:+ExitOnOutOfMemoryError -Xmx1G -XX:+UseZGC
             -Dpulsar.allocator.pooled=true
             -Dpulsar.allocator.leak_detection=Advanced
             -Dpulsar.allocator.exit_on_oom=false

--- a/tests/docker-images/latest-version-image/conf/bookie.conf
+++ b/tests/docker-images/latest-version-image/conf/bookie.conf
@@ -22,6 +22,6 @@ autostart=false
 redirect_stderr=true
 stdout_logfile=/var/log/pulsar/bookie.log
 directory=/pulsar
-environment=PULSAR_MEM="-Xmx128M -XX:MaxDirectMemorySize=512M",PULSAR_GC="-XX:+UseG1GC"
+environment=PULSAR_MEM="-Xmx128M -XX:MaxDirectMemorySize=512M",PULSAR_GC="-XX:+UseZGC"
 command=/pulsar/bin/pulsar bookie
 user=pulsar

--- a/tests/docker-images/latest-version-image/conf/broker.conf
+++ b/tests/docker-images/latest-version-image/conf/broker.conf
@@ -22,6 +22,6 @@ autostart=false
 redirect_stderr=true
 stdout_logfile=/var/log/pulsar/broker.log
 directory=/pulsar
-environment=PULSAR_MEM="-Xmx128M",PULSAR_GC="-XX:+UseG1GC"
+environment=PULSAR_MEM="-Xmx128M",PULSAR_GC="-XX:+UseZGC"
 command=/pulsar/bin/pulsar broker
 user=pulsar

--- a/tests/docker-images/latest-version-image/conf/functions_worker.conf
+++ b/tests/docker-images/latest-version-image/conf/functions_worker.conf
@@ -22,6 +22,6 @@ autostart=false
 redirect_stderr=true
 stdout_logfile=/var/log/pulsar/functions_worker.log
 directory=/pulsar
-environment=PULSAR_MEM="-Xmx128M",PULSAR_GC="-XX:+UseG1GC"
+environment=PULSAR_MEM="-Xmx128M",PULSAR_GC="-XX:+UseZGC"
 command=/pulsar/bin/pulsar functions-worker
 user=pulsar

--- a/tests/docker-images/latest-version-image/conf/global-zk.conf
+++ b/tests/docker-images/latest-version-image/conf/global-zk.conf
@@ -22,6 +22,6 @@ autostart=false
 redirect_stderr=true
 stdout_logfile=/var/log/pulsar/global-zk.log
 directory=/pulsar
-environment=PULSAR_MEM="-Xmx128M",PULSAR_GC="-XX:+UseG1GC"
+environment=PULSAR_MEM="-Xmx128M",PULSAR_GC="-XX:+UseZGC"
 command=/pulsar/bin/pulsar configuration-store
 user=pulsar

--- a/tests/docker-images/latest-version-image/conf/local-zk.conf
+++ b/tests/docker-images/latest-version-image/conf/local-zk.conf
@@ -22,6 +22,6 @@ autostart=false
 redirect_stderr=true
 stdout_logfile=/var/log/pulsar/local-zk.log
 directory=/pulsar
-environment=PULSAR_MEM="-Xmx128M",PULSAR_GC="-XX:+UseG1GC"
+environment=PULSAR_MEM="-Xmx128M",PULSAR_GC="-XX:+UseZGC"
 command=/pulsar/bin/pulsar zookeeper
 user=pulsar

--- a/tests/docker-images/latest-version-image/conf/presto/jvm.config
+++ b/tests/docker-images/latest-version-image/conf/presto/jvm.config
@@ -20,8 +20,7 @@
 -server
 -Xms128M
 -Xmx1500M
--XX:+UseG1GC
--XX:G1HeapRegionSize=32M
+-XX:+UseZGC
 -XX:+UseGCOverheadLimit
 -XX:+ExplicitGCInvokesConcurrent
 -XX:+HeapDumpOnOutOfMemoryError

--- a/tests/docker-images/latest-version-image/conf/presto_worker.conf
+++ b/tests/docker-images/latest-version-image/conf/presto_worker.conf
@@ -22,6 +22,6 @@ autostart=false
 redirect_stderr=true
 stdout_logfile=/var/log/pulsar/presto_worker.log
 directory=/pulsar
-environment=PULSAR_MEM="-Xmx128M",PULSAR_GC="-XX:+UseG1GC"
+environment=PULSAR_MEM="-Xmx128M",PULSAR_GC="-XX:+UseZGC"
 command=/pulsar/bin/pulsar sql-worker start
 user=pulsar

--- a/tests/docker-images/latest-version-image/conf/proxy.conf
+++ b/tests/docker-images/latest-version-image/conf/proxy.conf
@@ -22,6 +22,6 @@ autostart=false
 redirect_stderr=true
 stdout_logfile=/var/log/pulsar/proxy.log
 directory=/pulsar
-environment=PULSAR_MEM="-Xmx128M",PULSAR_GC="-XX:+UseG1GC"
+environment=PULSAR_MEM="-Xmx128M",PULSAR_GC="-XX:+UseZGC"
 command=/pulsar/bin/pulsar proxy
 user=pulsar


### PR DESCRIPTION
# Pulsar Server Default GC Update

As Java 17 will be officially required for pulsar-2.11+, it would be worth to revisit Pulsar’s GC default configurations 
and consider the newer GC, ZGC or ShenandoahGC as the new default.

## ZGC:
One could easily find ZGC intro articles[1][2][3]. I personally found the following persuasive.

“The primary goals of ZGC are low latency, scalability, and ease of use. To achieve this, ZGC allows a Java application to continue running while it performs all garbage collection operations except thread stack scanning. It scales from a few hundred MB to TB-size Java heaps, while consistently maintaining very low pause times—typically within 2 ms.
The implications of predictably low pause times could be profound for both application developers and system architects. Developers will no longer need to worry about designing elaborate ways to avoid garbage collection pauses. And system architects will not require specialized GC performance tuning expertise to achieve the dependably low pause times that are very important for so many use cases. This makes ZGC a good fit for applications that require large amounts of memory, such as with big data. However, ZGC is also a good candidate for smaller heaps that require predictable and extremely low pause times.”[3]

### The less settings, the better
One might further tune G1GC flags to outperform ZGC, but our goal is to make the default GC perform well enough to cover general use-cases —  it should be rare for users to further tune GC flags. It is promoted that ZGC requires less tunings.
1. ZGC is designed to guarantee low pause time
2. ZGC scales well independent of application heap-size, hundred MBs to TBs


## ShenandoahGC:
ShenandoahGC shares the similar designs to ZGC, promoting low pause time as well. Nonetheless, because ShenandoahGC is not officially supported by Oracle, it is unavailable in Oracle built OpenJdks[4][5]. Hence, between ShenandoahGC and ZGC, Pulsar probably needs to take a more available option, ZGC, also considering the future support.
Still, individual Pulsar users can override this default GC, depending on their use-case and OpenJdk versions.


[1] https://wiki.openjdk.java.net/display/zgc/Main

[2] https://developers.redhat.com/articles/2021/11/02/how-choose-best-java-garbage-collector

[3] https://blogs.oracle.com/javamagazine/post/understanding-the-jdks-new-superfast-garbage-collectors

[4] https://developers.redhat.com/blog/2019/04/19/not-all-openjdk-12-builds-include-shenandoah-heres-why

[5] https://bugs.openjdk.java.net/browse/JDK-8215030

## Performance Tests:

To confirm the performance benefits, we conducted the open-messaging benchmark.
In this test, we skipped journalings to give more pressures on JVM GCs.

### Max Throughput Test
- Workload : 1-topic-100-partitions-1kb-4p-4c-2000k

| |Java11 G1GC | Java17 G1GC |Java17 ZGC | Java17 ShenandoahGC |
|:---|:----|:-----|:---------|:--------------------------------|
|Avg Pub rate(mb/s)|  1784| 1703|1711|1618|
|Avg Cons rate(mb/s)| 1778| 1701|1711|1619|
|Avg Backlog cnt(k)| 3159 | 121|30|64|
|Avg Pub latency(ms)| 286|299 |296|294|


### Latency Test
- Workload: 100-partitions-1kb-4p-4c-500k

| |Java11 G1GC | Java17 G1GC |Java17 ZGC | Java17 ShenandoahGC |
|:---|:----|:-----|:---------|:--------------------------------|
|P999 Pub latency(ms)| 1.8 | 2.1| 2.1| 2.0|
|P9999 Pub latency(ms)| 37.7 |32.9|20.2 | 37|


### Test Result Analysis
#### ZGC performs well

From the Max Throughput Test, ZGC performed well by keeping the lowest backlogs, avg 30k 
while maintaining avg 1711mb/s throughput.

From the Latency Test, although the latency difference is not very significant,
ZGC showed the lowest p9999 Pub latency, 20.2ms.


## Pulsar Default GC Flag Update Proposal

Fork PR : https://github.com/heesung-sn/pulsar/pull/1

### Before:
https://github.com/apache/pulsar/blob/master/conf/pulsar_env.sh#L48

- -XX:+UseG1GC
- -XX:MaxGCPauseMillis=10
- -XX:+ParallelRefProcEnabled
- -XX:+UnlockExperimentalVMOptions
- -XX:+DoEscapeAnalysis
- -XX:ParallelGCThreads=32
- -XX:ConcGCThreads=32
- -XX:G1NewSizePercent=50
- -XX:+DisableExplicitGC

### After:
- -XX:+UseZGC
- -XX:+PerfDisableSharedMem
- -XX:+AlwaysPreTouch

### Update Details

- Replace -XX:+UseG1GC with -XX:+ZGC

  - Pulsar adapts new GC technologies, which guarantees low latency, scalability, and ease of use
  - ZGC performs well on Pulsar according to the test result above

- Remove -XX:MaxGCPauseMillis=10
  - irrelevant for ZGC. Instead, we rely on induced pause-time in ZGC.
  - ref: https://wiki.openjdk.java.net/display/zgc/Main
- Remove -XX:+ParallelRefProcEnabled
  - irrelevant for ZGC. ZGC logic is inherently concurrent including reference processor logic. ZReferenceProcessor uses ZWorkers whose size is initialized based on ParallelGCThreads and ConcGCThreads
  - ref: https://wiki.openjdk.java.net/display/zgc/Main
  - ref: https://github.com/openjdk/zgc/blob/master/src/hotspot/share/gc/z/zReferenceProcessor.cpp#L423-L434
  - ref: https://github.com/openjdk/zgc/blob/master/src/hotspot/share/gc/z/zWorkers.cpp#L64-L66
- Remove XX:+UnlockExperimentalVMOptions
    - Not required for ZGC in Java17.
    - ref: https://wiki.openjdk.java.net/display/zgc/Main
- Remove -XX:+DoEscapeAnalysis:
    - enabled by default in Java17. no needs to be explicit for this flag
    - ref: https://docs.oracle.com/en/java/javase/17/docs/specs/man/java.html
- Remove -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32
    - These are hardcoded thread counts, which could be over/under-sized depending on the runtime instance types. We better to use the default thread counts which are proportional to the number of cores on the instance. By default, ZGC configures 60% of cpu for XX:ParallelGCThreads and 25% of cpu for XX:ConcGCThreads.
    - ref: https://docs.oracle.com/en/java/javase/17/docs/specs/man/java.html
    - ref: https://github.com/openjdk/zgc/blob/master/src/hotspot/share/gc/z/zHeuristics.cpp#L87-L104
    - ref: https://github.com/openjdk/zgc/blob/master/src/hotspot/share/gc/z/zArguments.cpp#L57-L73
- Remove -XX:G1NewSizePercent=50
    - This is for G1GC specific setup. irrelevant for ZGC
    - ref: https://wiki.openjdk.java.net/display/zgc/Main
- Remove -XX:+DisableExplicitGC
    - pulsar code should not explicitly call System.gc().
    - ref: https://docs.oracle.com/en/java/javase/17/docs/specs/man/java.html
- Add -XX:+PerfDisableSharedMem 
  - During GC, writing JVM performance data in the shared memory could take a long time due to disk i/o, unless RAM disk, tmpfs is configured for the JVM performance data file.
  - ref: https://github.com/openjdk/zgc/blob/master/src/hotspot/os/posix/perfMemory_posix.cpp#L1219-L1232
  - ref: https://issues.apache.org/jira/browse/CASSANDRA-9242
  - ref: https://groups.google.com/g/mechanical-sympathy/c/9SP4IM-MUrI
- Add -XX:+AlwaysPreTouch
  - This will reduce the cold start latency, when converting virtual memory to physical memory. The tradeoff is that it will reduce page access time later, as the pages will already be loaded into memory(higher server bootstrap time).
  - ref: https://docs.oracle.com/en/java/javase/17/docs/specs/man/java.html
  - ref: https://access.redhat.com/solutions/2685771
