### PR TITLE
[improve][tableview] added isActive() method and faultTolerant mode

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/TableView.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/TableView.java
@@ -103,4 +103,14 @@ public interface TableView<T> extends Closeable {
      * @return a future that can used to track when the table view has been closed.
      */
     CompletableFuture<Void> closeAsync();
+
+    /**
+     *  Checks if the table view is actively reading messages.
+     *
+     *  For example, if the internal reader is interrupted, the table view may be in the inactive state
+     *  and stop reading messages. In this case, the caller may recreate a new table view.
+     *
+     *  @return true if active. false if inactive.
+     */
+    boolean isActive();
 }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/TableViewBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/TableViewBuilder.java
@@ -92,4 +92,14 @@ public interface TableViewBuilder<T> {
      * @return the {@link TableViewBuilder} builder instance
      */
     TableViewBuilder<T> autoUpdatePartitionsInterval(int interval, TimeUnit unit);
+
+
+    /**
+     * Set the fault tolerant mode.
+     * If set true, the table view automatically tries to recover the table view state from failures.
+     * By default, faultTolerant is false.
+     * @param  faultTolerant true or false
+     * @return the {@link TableViewBuilder} builder instance
+     */
+    TableViewBuilder<T> faultTolerant(boolean faultTolerant);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewBuilderImpl.java
@@ -76,4 +76,10 @@ public class TableViewBuilderImpl<T> implements TableViewBuilder<T> {
        conf.setAutoUpdatePartitionsSeconds(unit.toSeconds(interval));
        return this;
     }
+
+    @Override
+    public TableViewBuilder<T> faultTolerant(boolean faultTolerant) {
+        conf.setFaultTolerant(faultTolerant);
+        return this;
+    }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewConfigurationData.java
@@ -30,6 +30,7 @@ public class TableViewConfigurationData implements Serializable, Cloneable {
 
     private String topicName = null;
     private long autoUpdatePartitionsSeconds = 60;
+    private boolean faultTolerant = false;
 
     @Override
     public TableViewConfigurationData clone() {
@@ -37,6 +38,7 @@ public class TableViewConfigurationData implements Serializable, Cloneable {
             TableViewConfigurationData clone = (TableViewConfigurationData) super.clone();
             clone.setTopicName(topicName);
             clone.setAutoUpdatePartitionsSeconds(autoUpdatePartitionsSeconds);
+            clone.setFaultTolerant(faultTolerant);
             return clone;
         } catch (CloneNotSupportedException e) {
             throw new AssertionError();


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #<xyz>

<!-- or this PR is one task of an issue -->

Master Issue: #<xyz>

### Motivation

I ran into a situation where all table view readers are interrupted and stopped reading messages when the internal readers of the table view are closed.

[https://github.com/apache/pulsar/blob/722c56dfcad97b46f8483b1729821a794f9e7426/pul[…]/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java](https://github.com/apache/pulsar/blob/722c56dfcad97b46f8483b1729821a794f9e7426/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java#L223-L224)
```
    private void readTailMessages(Reader<T> reader) {
        reader.readNextAsync()
                .thenAccept(msg -> {
                    handleMessage(msg);
                    readTailMessages(reader);
                }).exceptionally(ex -> {
                    log.info("Reader {} was interrupted", reader.getTopic());  <========= here
                    return null;
                });
```

This is an example exception thrown in the above code.

```
2022-09-15T10:42:00,857 - WARN  - [broker-client-shared-internal-executor-85-1:TableViewImpl@322] - Reader persistent://pulsar/system/broker-load-data was interrupted
java.util.concurrent.CompletionException: org.apache.pulsar.client.api.PulsarClientException$AlreadyClosedException: The consumer which subscribes the topic persistent://pulsar/system/broker-load-data with subscription name reader-66b8e79459 was already closed when cleaning and closing the consumers
	at java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:332) ~[?:?]
	at java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:347) ~[?:?]
	at java.util.concurrent.CompletableFuture$UniAccept.tryFire$$$capture(CompletableFuture.java:708) ~[?:?]
	at java.util.concurrent.CompletableFuture$UniAccept.tryFire(CompletableFuture.java) ~[?:?]
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510) ~[?:?]
	at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2162) ~[?:?]
	at org.apache.pulsar.client.impl.ConsumerBase.failPendingReceives(ConsumerBase.java:324) ~[pulsar-client-original-2.11.0-SNAPSHOT.jar:2.11.0-SNAPSHOT]
	at org.apache.pulsar.client.impl.ConsumerBase.lambda$failPendingReceive$1(ConsumerBase.java:307) ~[pulsar-client-original-2.11.0-SNAPSHOT.jar:2.11.0-SNAPSHOT]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[netty-common-4.1.77.Final.jar:4.1.77.Final]
	at java.lang.Thread.run(Thread.java:833) ~[?:?]
Caused by: org.apache.pulsar.client.api.PulsarClientException$AlreadyClosedException: The consumer which subscribes the topic persistent://pulsar/system/broker-load-data with subscription name reader-66b8e79459 was already closed when cleaning and closing the consumers
	at org.apache.pulsar.client.impl.ConsumerBase.failPendingReceives(ConsumerBase.java:326) ~[pulsar-client-original-2.11.0-SNAPSHOT.jar:2.11.0-SNAPSHOT]
	... 5 more
```

In this case, currently, there is no way for the caller to know that the table view stopped reading messages and the table view silently stop reading messages.


<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications

- Adds a public method, `inActive()` in the `TableView` for the caller to check if the table view is actively reading messages.
- Adds the `faultTolerant` mode in the `TableView` to automatically recover the table-view state from failures.

<!-- Describe the modifications you've done. -->

### Verifying this change

- [x] Make sure that the change passes the CI checks.
  - Added a test case `testInActive` in `TableViewTest`.


### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [x] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
