### PR TITLE
Changed the aggregatePublisherStatsByProducerName config default to true

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1486,7 +1486,7 @@ splitTopicAndPartitionLabelInPrometheus=false
 
 # If true and the client supports partial producer, aggregate publisher stats of PartitionedTopicStats by producerName.
 # Otherwise, aggregate it by list index.
-aggregatePublisherStatsByProducerName=false
+aggregatePublisherStatsByProducerName=true
 
 # Interval between checks to see if cluster is migrated and marks topic migrated
 # if cluster is marked migrated. Disable with value 0. (Default disabled).

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -996,7 +996,7 @@ splitTopicAndPartitionLabelInPrometheus=false
 
 # If true, aggregate publisher stats of PartitionedTopicStats by producerName.
 # Otherwise, aggregate it by list index.
-aggregatePublisherStatsByProducerName=false
+aggregatePublisherStatsByProducerName=true
 
 ### --- Schema storage --- ###
 # The schema storage implementation used by this broker.

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2728,7 +2728,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
         category = CATEGORY_METRICS,
         doc = "If true, aggregate publisher stats of PartitionedTopicStats by producerName"
     )
-    private boolean aggregatePublisherStatsByProducerName = false;
+    private boolean aggregatePublisherStatsByProducerName = true;
 
     /**** --- Ledger Offloading. --- ****/
     /****


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

### Motivation
The index-based publisher stat aggregation(configured by `aggregatePublisherStatsByProducerName`=false, default, triggered by `pulsar-admin topics partitioned-stats api`) can wrongly aggregate publisher metrics if each partition stat returns a different size or order of the publisher stat list. To avoid this issue, aggregatePublisherStatsByProducerName=true is the better default choice, as the state aggregation will be grouped by a unique key,  producer names.

Discussion Thread:

https://lists.apache.org/thread/vofv1oz0wvzlwk4x9vk067rhkscn8bqo


<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications
- Updated the aggregatePublisherStatsByProducerName config default to `true`.


<!-- Describe the modifications you've done. -->

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [x] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/heesung-sn/pulsar/pull/15

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
