### PR TITLE
[improve][broker] PIP-192 Moved the common broker load data feature(weightedMaxEMA) to BrokerLoadData

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/data/BrokerLoadData.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/data/BrokerLoadData.java
@@ -52,7 +52,20 @@ public class BrokerLoadData {
 
     // Load data features computed from the above resources.
     private double maxResourceUsage; // max of resource usages
-    private double weightedMaxEMA; // exponential moving average of max of weighted resource usages
+    /**
+     * Exponential moving average(EMA) of max of weighted resource usages among
+     * cpu, memory, directMemory, bandwidthIn and bandwidthOut.
+     *
+     * The resource weights are configured by :
+     * loadBalancerCPUResourceWeight,
+     * loadBalancerMemoryResourceWeight,
+     * loadBalancerDirectMemoryResourceWeight,
+     * loadBalancerBandwithInResourceWeight, and
+     * loadBalancerBandwithOutResourceWeight.
+     *
+     * The historical resource percentage is configured by loadBalancerHistoryResourcePercentage.
+     */
+    private double weightedMaxEMA;
     private long updatedAt;
 
     public BrokerLoadData() {
@@ -143,7 +156,6 @@ public class BrokerLoadData {
                 bandwidthOut.percentUsage() * bandwidthOutWeight) / 100;
     }
 
-
     private void updateWeightedMaxEMA(ServiceConfiguration conf) {
         var historyPercentage = conf.getLoadBalancerHistoryResourcePercentage();
         var weightedMax = getMaxResourceUsageWithWeight(
@@ -153,6 +165,26 @@ public class BrokerLoadData {
                 conf.getLoadBalancerBandwithOutResourceWeight());
         weightedMaxEMA = updatedAt == 0 ? weightedMax :
                 weightedMaxEMA * historyPercentage + (1 - historyPercentage) * weightedMax;
+    }
+
+    public String toString(ServiceConfiguration conf) {
+        return String.format("cpu= %.2f%%, memory= %.2f%%, directMemory= %.2f%%, "
+                        + "bandwithIn= %.2f%%, bandwithOut= %.2f%%, "
+                        + "cpuWeight= %f, memoryWeight= %f, directMemoryWeight= %f, "
+                        + "bandwithInResourceWeight= %f, bandwithOutResourceWeight= %f, "
+                        + "msgThroughputIn= %.2f, msgThroughputOut= %.2f, msgRateIn= %.2f, msgRateOut= %.2f, "
+                        + "maxResourceUsage= %.2f%%, weightedMaxEMA= %.2f%%, updatedAt= %d",
+
+                cpu.percentUsage(), memory.percentUsage(), directMemory.percentUsage(),
+                bandwidthIn.percentUsage(), bandwidthOut.percentUsage(),
+                conf.getLoadBalancerCPUResourceWeight(),
+                conf.getLoadBalancerMemoryResourceWeight(),
+                conf.getLoadBalancerDirectMemoryResourceWeight(),
+                conf.getLoadBalancerBandwithInResourceWeight(),
+                conf.getLoadBalancerBandwithOutResourceWeight(),
+                msgThroughputIn, msgThroughputOut, msgRateIn, msgRateOut,
+                maxResourceUsage * 100, weightedMaxEMA * 100, updatedAt
+        );
     }
 
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/data/BrokerLoadData.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/data/BrokerLoadData.java
@@ -18,7 +18,8 @@
  */
 package org.apache.pulsar.broker.loadbalance.extensions.data;
 
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.policies.data.loadbalancer.LocalBrokerData;
 import org.apache.pulsar.policies.data.loadbalancer.ResourceUsage;
@@ -30,27 +31,29 @@ import org.apache.pulsar.policies.data.loadbalancer.SystemResourceUsage;
  * Migrate from {@link org.apache.pulsar.policies.data.loadbalancer.LocalBrokerData}.
  * And removed the lookup data, see {@link BrokerLookupData}
  */
-@Data
+@Getter
+@EqualsAndHashCode
 public class BrokerLoadData {
+
+    private static final double DEFAULT_RESOURCE_USAGE = 1.0d;
 
     // Most recently available system resource usage.
     private ResourceUsage cpu;
     private ResourceUsage memory;
     private ResourceUsage directMemory;
-
     private ResourceUsage bandwidthIn;
     private ResourceUsage bandwidthOut;
 
     // Message data from the most recent namespace bundle stats.
-    private double msgThroughputIn;
-    private ResourceUsage msgThroughputInUsage;
-    private double msgThroughputOut;
-    private ResourceUsage msgThroughputOutUsage;
-    private double msgRateIn;
-    private double msgRateOut;
+    private double msgThroughputIn; // bytes/sec
+    private double msgThroughputOut;  // bytes/sec
+    private double msgRateIn; // messages/sec
+    private double msgRateOut; // messages/sec
 
-    // load data features
-    private Double weightedMaxEMA; // exponential moving average of max of weighted resource usages
+    // Load data features computed from the above resources.
+    private double maxResourceUsage; // max of resource usages
+    private double weightedMaxEMA; // exponential moving average of max of weighted resource usages
+    private long updatedAt;
 
     public BrokerLoadData() {
         cpu = new ResourceUsage();
@@ -58,37 +61,56 @@ public class BrokerLoadData {
         directMemory = new ResourceUsage();
         bandwidthIn = new ResourceUsage();
         bandwidthOut = new ResourceUsage();
-        msgThroughputInUsage = new ResourceUsage();
-        msgThroughputOutUsage = new ResourceUsage();
-        weightedMaxEMA = null;
+        maxResourceUsage = DEFAULT_RESOURCE_USAGE;
+        weightedMaxEMA = DEFAULT_RESOURCE_USAGE;
     }
 
     /**
-     * Using the system resource usage and bundle stats acquired from the Pulsar client, update this LocalBrokerData.
+     * Using the system resource usage from the Pulsar client, update this BrokerLoadData.
      *
-     * @param systemResourceUsage
+     * @param usage
      *            System resource usage (cpu, memory, and direct memory).
+     * @param msgThroughputIn
+     *            broker-level message input throughput in bytes/s.
+     * @param msgThroughputOut
+     *            broker-level message output throughput in bytes/s.
+     * @param msgRateIn
+     *            broker-level message input rate in messages/s.
+     * @param msgRateOut
+     *            broker-level message output rate in messages/s.
+     * @param conf
+     *            Service configuration to compute load data features.
      */
-    public void update(final SystemResourceUsage systemResourceUsage, ServiceConfiguration conf) {
-        updateSystemResourceUsage(systemResourceUsage);
+    public void update(final SystemResourceUsage usage,
+                       double msgThroughputIn,
+                       double msgThroughputOut,
+                       double msgRateIn,
+                       double msgRateOut,
+                       ServiceConfiguration conf) {
+        updateSystemResourceUsage(usage.cpu, usage.memory, usage.directMemory, usage.bandwidthIn, usage.bandwidthOut);
+        this.msgThroughputIn = msgThroughputIn;
+        this.msgThroughputOut = msgThroughputOut;
+        this.msgRateIn = msgRateIn;
+        this.msgRateOut = msgRateOut;
         updateFeatures(conf);
+        updatedAt = System.currentTimeMillis();
     }
 
     /**
-     * Using another LocalBrokerData, update this.
+     * Using another BrokerLoadData, update this.
      *
      * @param other
-     *            LocalBrokerData to update from.
+     *            BrokerLoadData to update from.
      */
-    public void update(final BrokerLoadData other, ServiceConfiguration conf) {
+    public void update(final BrokerLoadData other) {
         updateSystemResourceUsage(other.cpu, other.memory, other.directMemory, other.bandwidthIn, other.bandwidthOut);
-        updateFeatures(conf);
-    }
-
-    // Set the cpu, memory, and direct memory to that of the new system resource usage data.
-    private void updateSystemResourceUsage(final SystemResourceUsage systemResourceUsage) {
-        updateSystemResourceUsage(systemResourceUsage.cpu, systemResourceUsage.memory, systemResourceUsage.directMemory,
-                systemResourceUsage.bandwidthIn, systemResourceUsage.bandwidthOut);
+        msgThroughputIn = other.msgThroughputIn;
+        msgThroughputOut = other.msgThroughputOut;
+        msgRateIn = other.msgRateIn;
+        msgRateOut = other.msgRateOut;
+        weightedMaxEMA = other.weightedMaxEMA;
+        maxResourceUsage = other.maxResourceUsage;
+        updatedAt = other.updatedAt;
     }
 
     // Update resource usage given each individual usage.
@@ -102,12 +124,18 @@ public class BrokerLoadData {
         this.bandwidthOut = bandwidthOut;
     }
 
-    public double getMaxResourceUsage() {
-        return LocalBrokerData.max(cpu.percentUsage(), directMemory.percentUsage(), bandwidthIn.percentUsage(),
+    private void updateFeatures(ServiceConfiguration conf) {
+        updateMaxResourceUsage();
+        updateWeightedMaxEMA(conf);
+    }
+
+    private void updateMaxResourceUsage() {
+        maxResourceUsage = LocalBrokerData.max(cpu.percentUsage(), directMemory.percentUsage(),
+                bandwidthIn.percentUsage(),
                 bandwidthOut.percentUsage()) / 100;
     }
 
-    public double getMaxResourceUsageWithWeight(final double cpuWeight, final double memoryWeight,
+    private double getMaxResourceUsageWithWeight(final double cpuWeight, final double memoryWeight,
                                                 final double directMemoryWeight, final double bandwidthInWeight,
                                                 final double bandwidthOutWeight) {
         return LocalBrokerData.max(cpu.percentUsage() * cpuWeight, memory.percentUsage() * memoryWeight,
@@ -115,18 +143,15 @@ public class BrokerLoadData {
                 bandwidthOut.percentUsage() * bandwidthOutWeight) / 100;
     }
 
-    private void updateFeatures(ServiceConfiguration conf) {
-        updateWeightedMaxEMA(conf);
-    }
 
-    public void updateWeightedMaxEMA(ServiceConfiguration conf) {
+    private void updateWeightedMaxEMA(ServiceConfiguration conf) {
         var historyPercentage = conf.getLoadBalancerHistoryResourcePercentage();
         var weightedMax = getMaxResourceUsageWithWeight(
                 conf.getLoadBalancerCPUResourceWeight(),
                 conf.getLoadBalancerMemoryResourceWeight(), conf.getLoadBalancerDirectMemoryResourceWeight(),
                 conf.getLoadBalancerBandwithInResourceWeight(),
                 conf.getLoadBalancerBandwithOutResourceWeight());
-        weightedMaxEMA = weightedMaxEMA == null ? weightedMax :
+        weightedMaxEMA = updatedAt == 0 ? weightedMax :
                 weightedMaxEMA * historyPercentage + (1 - historyPercentage) * weightedMax;
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/strategy/LeastResourceUsageWithWeight.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/strategy/LeastResourceUsageWithWeight.java
@@ -37,7 +37,6 @@ import org.apache.pulsar.common.naming.ServiceUnitId;
  */
 @Slf4j
 public class LeastResourceUsageWithWeight implements BrokerSelectionStrategy {
-    private static final double MAX_RESOURCE_USAGE = 1.0d;
     // Maintain this list to reduce object creation.
     private final ArrayList<String> bestBrokers;
     private final Set<String> noLoadDataBrokers;
@@ -52,6 +51,7 @@ public class LeastResourceUsageWithWeight implements BrokerSelectionStrategy {
                                                  final ServiceConfiguration conf, boolean debugMode) {
         final double overloadThreshold = conf.getLoadBalancerBrokerOverloadedThresholdPercentage() / 100.0;
         final var maxUsageWithWeight = brokerLoadData.getWeightedMaxEMA();
+
         if (maxUsageWithWeight > overloadThreshold) {
             log.warn(
                     "Broker {} is overloaded, max resource usage with weight percentage: {}%, "
@@ -128,8 +128,7 @@ public class LeastResourceUsageWithWeight implements BrokerSelectionStrategy {
                     log.warn("There is no broker load data for broker:{}. Skipping this broker. Phase two", broker);
                     continue;
                 }
-                Double avgResUsageObj = brokerLoadDataOptional.get().getWeightedMaxEMA();
-                double avgResUsage = avgResUsageObj == null ? MAX_RESOURCE_USAGE : avgResUsageObj.doubleValue();
+                double avgResUsage = brokerLoadDataOptional.get().getWeightedMaxEMA();
                 if ((avgResUsage + diffThreshold <= avgUsage && !noLoadDataBrokers.contains(broker))) {
                     bestBrokers.add(broker);
                 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/strategy/LeastResourceUsageWithWeight.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/strategy/LeastResourceUsageWithWeight.java
@@ -19,10 +19,8 @@
 package org.apache.pulsar.broker.loadbalance.extensions.strategy;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
@@ -43,11 +41,9 @@ public class LeastResourceUsageWithWeight implements BrokerSelectionStrategy {
     // Maintain this list to reduce object creation.
     private final ArrayList<String> bestBrokers;
     private final Set<String> noLoadDataBrokers;
-    private final Map<String, Double> brokerAvgResourceUsageWithWeight;
 
     public LeastResourceUsageWithWeight() {
         this.bestBrokers = new ArrayList<>();
-        this.brokerAvgResourceUsageWithWeight = new HashMap<>();
         this.noLoadDataBrokers = new HashSet<>();
     }
 
@@ -55,9 +51,7 @@ public class LeastResourceUsageWithWeight implements BrokerSelectionStrategy {
     private double getMaxResourceUsageWithWeight(final String broker, final BrokerLoadData brokerLoadData,
                                                  final ServiceConfiguration conf, boolean debugMode) {
         final double overloadThreshold = conf.getLoadBalancerBrokerOverloadedThresholdPercentage() / 100.0;
-        final double maxUsageWithWeight =
-                updateAndGetMaxResourceUsageWithWeight(broker, brokerLoadData, conf, debugMode);
-
+        final var maxUsageWithWeight = brokerLoadData.getWeightedMaxEMA();
         if (maxUsageWithWeight > overloadThreshold) {
             log.warn(
                     "Broker {} is overloaded, max resource usage with weight percentage: {}%, "
@@ -80,40 +74,6 @@ public class LeastResourceUsageWithWeight implements BrokerSelectionStrategy {
         return maxUsageWithWeight;
     }
 
-    /**
-     * Update and get the max resource usage with weight of broker according to the service configuration.
-     *
-     * @param broker     The broker name.
-     * @param brokerData The broker load data.
-     * @param conf       The service configuration.
-     * @param debugMode  The debug mode to print computed load states and decision information.
-     * @return the max resource usage with weight of broker
-     */
-    private double updateAndGetMaxResourceUsageWithWeight(String broker, BrokerLoadData brokerData,
-                                                          ServiceConfiguration conf, boolean debugMode) {
-        final double historyPercentage = conf.getLoadBalancerHistoryResourcePercentage();
-        Double historyUsage = brokerAvgResourceUsageWithWeight.get(broker);
-        double resourceUsage = brokerData.getMaxResourceUsageWithWeight(
-                conf.getLoadBalancerCPUResourceWeight(),
-                conf.getLoadBalancerMemoryResourceWeight(),
-                conf.getLoadBalancerDirectMemoryResourceWeight(),
-                conf.getLoadBalancerBandwithInResourceWeight(),
-                conf.getLoadBalancerBandwithOutResourceWeight());
-        historyUsage = historyUsage == null
-                ? resourceUsage : historyUsage * historyPercentage + (1 - historyPercentage) * resourceUsage;
-        if (debugMode) {
-            log.info(
-                    "Broker {} get max resource usage with weight: {}, history resource percentage: {}%, CPU weight: "
-                            + "{}, MEMORY weight: {}, DIRECT MEMORY weight: {}, BANDWIDTH IN weight: {}, BANDWIDTH "
-                            + "OUT weight: {} ",
-                    broker, historyUsage, historyPercentage, conf.getLoadBalancerCPUResourceWeight(),
-                    conf.getLoadBalancerMemoryResourceWeight(), conf.getLoadBalancerDirectMemoryResourceWeight(),
-                    conf.getLoadBalancerBandwithInResourceWeight(),
-                    conf.getLoadBalancerBandwithOutResourceWeight());
-        }
-        brokerAvgResourceUsageWithWeight.put(broker, historyUsage);
-        return historyUsage;
-    }
 
     /**
      * Find a suitable broker to assign the given bundle to.
@@ -143,7 +103,7 @@ public class LeastResourceUsageWithWeight implements BrokerSelectionStrategy {
         for (String broker : candidates) {
             var brokerLoadDataOptional = context.brokerLoadDataStore().get(broker);
             if (brokerLoadDataOptional.isEmpty()) {
-                log.warn("There is no broker load data for broker:{}. Skipping this broker.", broker);
+                log.warn("There is no broker load data for broker:{}. Skipping this broker. Phase one", broker);
                 noLoadDataBrokers.add(broker);
                 continue;
             }
@@ -162,12 +122,18 @@ public class LeastResourceUsageWithWeight implements BrokerSelectionStrategy {
             if (debugMode) {
                 log.info("Computed avgUsage:{}, diffThreshold:{}", avgUsage, diffThreshold);
             }
-            candidates.forEach(broker -> {
-                Double avgResUsage = brokerAvgResourceUsageWithWeight.getOrDefault(broker, MAX_RESOURCE_USAGE);
+            for (String broker : candidates) {
+                var brokerLoadDataOptional = context.brokerLoadDataStore().get(broker);
+                if (brokerLoadDataOptional.isEmpty()) {
+                    log.warn("There is no broker load data for broker:{}. Skipping this broker. Phase two", broker);
+                    continue;
+                }
+                Double avgResUsageObj = brokerLoadDataOptional.get().getWeightedMaxEMA();
+                double avgResUsage = avgResUsageObj == null ? MAX_RESOURCE_USAGE : avgResUsageObj.doubleValue();
                 if ((avgResUsage + diffThreshold <= avgUsage && !noLoadDataBrokers.contains(broker))) {
                     bestBrokers.add(broker);
                 }
-            });
+            }
         }
 
         if (bestBrokers.isEmpty()) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/strategy/LeastResourceUsageWithWeight.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/strategy/LeastResourceUsageWithWeight.java
@@ -52,25 +52,19 @@ public class LeastResourceUsageWithWeight implements BrokerSelectionStrategy {
         final double overloadThreshold = conf.getLoadBalancerBrokerOverloadedThresholdPercentage() / 100.0;
         final var maxUsageWithWeight = brokerLoadData.getWeightedMaxEMA();
 
+
         if (maxUsageWithWeight > overloadThreshold) {
             log.warn(
-                    "Broker {} is overloaded, max resource usage with weight percentage: {}%, "
-                            + "CPU: {}%, MEMORY: {}%, DIRECT MEMORY: {}%, BANDWIDTH IN: {}%, "
-                            + "BANDWIDTH OUT: {}%, CPU weight: {}, MEMORY weight: {}, DIRECT MEMORY weight: {}, "
-                            + "BANDWIDTH IN weight: {}, BANDWIDTH OUT weight: {}",
-                    broker, maxUsageWithWeight * 100,
-                    brokerLoadData.getCpu().percentUsage(), brokerLoadData.getMemory().percentUsage(),
-                    brokerLoadData.getDirectMemory().percentUsage(), brokerLoadData.getBandwidthIn().percentUsage(),
-                    brokerLoadData.getBandwidthOut().percentUsage(), conf.getLoadBalancerCPUResourceWeight(),
-                    conf.getLoadBalancerMemoryResourceWeight(), conf.getLoadBalancerDirectMemoryResourceWeight(),
-                    conf.getLoadBalancerBandwithInResourceWeight(),
-                    conf.getLoadBalancerBandwithOutResourceWeight());
+                    "Broker {} is overloaded, brokerLoad({}%) > overloadThreshold({}%). load data:{{}}",
+                    broker,
+                    maxUsageWithWeight * 100,
+                    overloadThreshold * 100,
+                    brokerLoadData.toString(conf));
+        } else if (debugMode) {
+            log.info("Broker {} load data:{{}}", broker, brokerLoadData.toString(conf));
         }
 
-        if (debugMode) {
-            log.info("Broker {} has max resource usage with weight percentage: {}%",
-                    broker, maxUsageWithWeight * 100);
-        }
+
         return maxUsageWithWeight;
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/data/BrokerLoadDataTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/data/BrokerLoadDataTest.java
@@ -100,6 +100,13 @@ public class BrokerLoadDataTest {
         assertEquals(data.getMaxResourceUsage(), 3.0);
         assertEquals(data.getWeightedMaxEMA(), 1.875);
         assertThat(data.getUpdatedAt(), greaterThanOrEqualTo(now));
+        assertEquals(data.toString(conf), "cpu= 300.00%, memory= 100.00%, directMemory= 2.00%, "
+                + "bandwithIn= 3.00%, bandwithOut= 4.00%, "
+                + "cpuWeight= 0.500000, memoryWeight= 0.500000, directMemoryWeight= 0.500000, "
+                + "bandwithInResourceWeight= 0.500000, bandwithOutResourceWeight= 0.500000, "
+                + "msgThroughputIn= 5.00, msgThroughputOut= 6.00, "
+                + "msgRateIn= 7.00, msgRateOut= 8.00,"
+                + " maxResourceUsage= 300.00%, weightedMaxEMA= 187.50%, updatedAt= " + data.getUpdatedAt());
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/data/BrokerLoadDataTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/data/BrokerLoadDataTest.java
@@ -18,10 +18,13 @@
  */
 package org.apache.pulsar.broker.loadbalance.extensions.data;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.testng.Assert.assertEquals;
 
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.policies.data.loadbalancer.ResourceUsage;
+import org.apache.pulsar.policies.data.loadbalancer.SystemResourceUsage;
 import org.testng.annotations.Test;
 
 /**
@@ -32,31 +35,8 @@ import org.testng.annotations.Test;
 public class BrokerLoadDataTest {
 
     @Test
-    public void testMaxResourceUsage() {
-        BrokerLoadData data = new BrokerLoadData();
-        data.setCpu(new ResourceUsage(1.0, 100.0));
-        data.setMemory(new ResourceUsage(800.0, 200.0));
-        data.setDirectMemory(new ResourceUsage(2.0, 100.0));
-        data.setBandwidthIn(new ResourceUsage(3.0, 100.0));
-        data.setBandwidthOut(new ResourceUsage(4.0, 100.0));
+    public void testUpdateBySystemResourceUsage() {
 
-        double epsilon = 0.00001;
-        double weight = 0.5;
-        // skips memory usage
-        assertEquals(data.getMaxResourceUsage(), 0.04, epsilon);
-
-        assertEquals(
-                data.getMaxResourceUsageWithWeight(
-                        weight, weight, weight, weight, weight), 2.0, epsilon);
-        assertEquals(
-                data.getWeightedMaxEMA(), null);
-    }
-
-    @Test
-    public void testWeightedMaxEMA() {
-        BrokerLoadData data = new BrokerLoadData();
-        assertEquals(
-                data.getWeightedMaxEMA(), null);
         ServiceConfiguration conf = new ServiceConfiguration();
         conf.setLoadBalancerCPUResourceWeight(0.5);
         conf.setLoadBalancerMemoryResourceWeight(0.5);
@@ -65,25 +45,92 @@ public class BrokerLoadDataTest {
         conf.setLoadBalancerBandwithOutResourceWeight(0.5);
         conf.setLoadBalancerHistoryResourcePercentage(0.75);
 
-        BrokerLoadData data2 = new BrokerLoadData();
-        data2.setCpu(new ResourceUsage(1.0, 100.0));
-        data2.setMemory(new ResourceUsage(800.0, 200.0));
-        data2.setDirectMemory(new ResourceUsage(2.0, 100.0));
-        data2.setBandwidthIn(new ResourceUsage(3.0, 100.0));
-        data2.setBandwidthOut(new ResourceUsage(4.0, 100.0));
-        data.update(data2, conf);
-        assertEquals(
-                data.getWeightedMaxEMA(), 2);
+        BrokerLoadData data = new BrokerLoadData();
 
-        BrokerLoadData data3 = new BrokerLoadData();
-        data3.setCpu(new ResourceUsage(300.0, 100.0));
-        data3.setMemory(new ResourceUsage(200.0, 200.0));
-        data3.setDirectMemory(new ResourceUsage(2.0, 100.0));
-        data3.setBandwidthIn(new ResourceUsage(3.0, 100.0));
-        data3.setBandwidthOut(new ResourceUsage(4.0, 100.0));
-        data.update(data3, conf);
-        assertEquals(
-                data.getWeightedMaxEMA(), 1.875);
+        long now = System.currentTimeMillis();
+        SystemResourceUsage usage1 = new SystemResourceUsage();
+        var cpu = new ResourceUsage(1.0, 100.0);
+        var memory = new ResourceUsage(800.0, 200.0);
+        var directMemory= new ResourceUsage(2.0, 100.0);
+        var bandwidthIn= new ResourceUsage(3.0, 100.0);
+        var bandwidthOut= new ResourceUsage(4.0, 100.0);
+        usage1.setCpu(cpu);
+        usage1.setMemory(memory);
+        usage1.setDirectMemory(directMemory);
+        usage1.setBandwidthIn(bandwidthIn);
+        usage1.setBandwidthOut(bandwidthOut);
+        data.update(usage1, 1,2,3,4, conf);
 
+        assertEquals(data.getCpu(), cpu);
+        assertEquals(data.getMemory(), memory);
+        assertEquals(data.getDirectMemory(), directMemory);
+        assertEquals(data.getBandwidthIn(), bandwidthIn);
+        assertEquals(data.getBandwidthOut(), bandwidthOut);
+        assertEquals(data.getMsgThroughputIn(), 1.0);
+        assertEquals(data.getMsgThroughputOut(), 2.0);
+        assertEquals(data.getMsgRateIn(), 3.0);
+        assertEquals(data.getMsgRateOut(), 4.0);
+        assertEquals(data.getMaxResourceUsage(), 0.04); // skips memory usage
+        assertEquals(data.getWeightedMaxEMA(), 2);
+        assertThat(data.getUpdatedAt(), greaterThanOrEqualTo(now));
+
+        now = System.currentTimeMillis();
+        SystemResourceUsage usage2 = new SystemResourceUsage();
+        cpu = new ResourceUsage(300.0, 100.0);
+        memory = new ResourceUsage(200.0, 200.0);
+        directMemory= new ResourceUsage(2.0, 100.0);
+        bandwidthIn= new ResourceUsage(3.0, 100.0);
+        bandwidthOut= new ResourceUsage(4.0, 100.0);
+        usage2.setCpu(cpu);
+        usage2.setMemory(memory);
+        usage2.setDirectMemory(directMemory);
+        usage2.setBandwidthIn(bandwidthIn);
+        usage2.setBandwidthOut(bandwidthOut);
+        data.update(usage2, 5,6,7,8, conf);
+
+        assertEquals(data.getCpu(), cpu);
+        assertEquals(data.getMemory(), memory);
+        assertEquals(data.getDirectMemory(), directMemory);
+        assertEquals(data.getBandwidthIn(), bandwidthIn);
+        assertEquals(data.getBandwidthOut(), bandwidthOut);
+        assertEquals(data.getMsgThroughputIn(), 5.0);
+        assertEquals(data.getMsgThroughputOut(), 6.0);
+        assertEquals(data.getMsgRateIn(), 7.0);
+        assertEquals(data.getMsgRateOut(), 8.0);
+        assertEquals(data.getMaxResourceUsage(), 3.0);
+        assertEquals(data.getWeightedMaxEMA(), 1.875);
+        assertThat(data.getUpdatedAt(), greaterThanOrEqualTo(now));
     }
+
+    @Test
+    public void testUpdateByBrokerLoadData() {
+        ServiceConfiguration conf = new ServiceConfiguration();
+        conf.setLoadBalancerCPUResourceWeight(0.5);
+        conf.setLoadBalancerMemoryResourceWeight(0.5);
+        conf.setLoadBalancerDirectMemoryResourceWeight(0.5);
+        conf.setLoadBalancerBandwithInResourceWeight(0.5);
+        conf.setLoadBalancerBandwithOutResourceWeight(0.5);
+        conf.setLoadBalancerHistoryResourcePercentage(0.75);
+
+        BrokerLoadData data = new BrokerLoadData();
+        BrokerLoadData other = new BrokerLoadData();
+
+        SystemResourceUsage usage1 = new SystemResourceUsage();
+        var cpu = new ResourceUsage(1.0, 100.0);
+        var memory = new ResourceUsage(800.0, 200.0);
+        var directMemory= new ResourceUsage(2.0, 100.0);
+        var bandwidthIn= new ResourceUsage(3.0, 100.0);
+        var bandwidthOut= new ResourceUsage(4.0, 100.0);
+        usage1.setCpu(cpu);
+        usage1.setMemory(memory);
+        usage1.setDirectMemory(directMemory);
+        usage1.setBandwidthIn(bandwidthIn);
+        usage1.setBandwidthOut(bandwidthOut);
+        other.update(usage1, 1,2,3,4, conf);
+        data.update(other);
+
+        assertEquals(data, other);
+    }
+
+
 }


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->


<!-- or this PR is one task of an issue -->

Master Issue: https://github.com/apache/pulsar/issues/16691

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->
We will start raising PRs to implement PIP-192, https://github.com/apache/pulsar/issues/16691

### Modifications
This PR moved the common broker load data feature(`weightedMaxEMA`) to `BrokerLoadData`.

As `weightedMaxEMA` is available in the `BrokerLoadData` by this change, this PR

- removed `brokerAvgResourceUsageWithWeight` in LeastResourceUsageWithWeight -- we don't need to separately compute and store `weightedMaxEMA` in `LeastResourceUsageWithWeight and TransferShedder`. 

- refactored `BrokerLoadData` to precompute the load data features.

- updated the unit tests.



<!-- Describe the modifications you've done. -->

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

  - *Added unit tests for the new classes.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

We will have separate PRs to update the Doc later.

### Matching PR in forked repository

PR in forked repository: https://github.com/heesung-sn/pulsar/pull/20

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
